### PR TITLE
Support Environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ cache:
 addons:
   sonarcloud:
     organization: "bordertech-github"
-    token:
-        secure: $SONAR_TOKEN
+    token: $SONAR_TOKEN
 
 before_install:
 - echo "MAVEN_OPTS='-Xmx512m -XX:MaxPermSize=128m'" > ~/.mavenrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Change log
+
+## Release in-progress
+
+### API Changes
+* The runtime property `bordertech.config.parameters.useSystemOverWriteOnly` now defaults to false which allows all system properties to be
+  merged when system properties enabled. Use the optional runtime property `bordertech.config.parameters.useSystemPrefixes` to limit the
+  properties merged.
+
+### Enhancements
+* Latest qa-parent
+* Ability to override the default config file name via a system or environment property `BT_CONFIG_FILE=my-config.properties`
+* Option to append extra resources to the defined resources via config property `bordertech.config.resources.append`
+* Option to load environment variables #13
+  * Enable via runtime property `bordertech.config.parameters.useEnvProperties=true`
+  * Option to limit variables merged via property `bordertech.config.parameters.useEnvPrefixes`. Defaults to allow all.
+
+## 1.0.5
+
+### Enhancements
+* Latest qa-parent #27
+* Improve README #24
+
+## 1.0.4
+
+### Enhancements
+* Optional dump parameters to a file. The file name can be set via runtime property `bordertech.config.parameters.dump.file`
+* Optional merge system properties into config.
+  * Enable system properties via runtime property `bordertech.config.parameters.useSystemProperties=true`
+  * Option to limit system properties merged via runtime property `bordertech.config.parameters.useSystemPrefixes`. Defaults to allow all.
+  * Defaults to only merge properties that already exist. Disable via runtime property `bordertech.config.parameters.useSystemOverWriteOnly=false`
+
+## 1.0.3
+
+### Enhancements
+* Latest qa-parent
+
+## 1.0.2
+* Latest qa-parent
+* Switch to travis
+* The reload of the configuration can be triggered via a touchfile. The touchfile can be set via the runtime property`bordertech.config.touchfile`.
+  To avoid excessive IO on the touchfile an interval (in milli seconds) between checks can be set via the runtime property
+ `bordertech.config.touchfile.interval` which defaults to 10000ms.
+
+## 1.0.1
+* Ability to define properties to only take effect in a certain environment. When the runtime property `bordertech.config.environment` is set,
+  it is used as the suffix for each property lookup. If no property exists with the current environment suffix then the default property (ie no
+  suffix) value is used.
+
+## 1.0.0
+* Initial version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Latest qa-parent
 * Ability to override the default config file name via a system or environment property `BT_CONFIG_FILE=my-config.properties`
 * Option to append extra resources to the defined resources via config property `bordertech.config.resources.append`
-* Option to load environment variables #13
+* Option to load environment variables #31
   * Enable via runtime property `bordertech.config.parameters.useEnvProperties=true`
   * Option to limit variables merged via property `bordertech.config.parameters.useEnvPrefixes`. Defaults to allow all.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=bordertech-java-config&metric=alert_status)](https://sonarcloud.io/dashboard?id=bordertech-java-config)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=bordertech-java-config&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=bordertech-java-config)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=bordertech-java-config&metric=coverage)](https://sonarcloud.io/dashboard?id=bordertech-java-config)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/738a3851c483470da86ffe1d047f344c)](https://www.codacy.com/app/BorderTech/java-config?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=BorderTech/java-config&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/ff9d14e9be2c4071b5e94bed4c7545cb)](https://www.codacy.com/gh/BorderTech/java-config?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=BorderTech/java-config&amp;utm_campaign=Badge_Grade)
 [![Javadocs](https://www.javadoc.io/badge/com.github.bordertech.config/config.svg)](https://www.javadoc.io/doc/com.github.bordertech.config/config)
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.bordertech.config/config.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.github.bordertech.config%22%20AND%20a:%22config%22)
 
@@ -87,7 +87,7 @@ include=another.properties
 
 It is possible to define properties to only take effect in a certain environment.
 
-When the environment property is set, it is used as the suffix for each property lookup:
+When the runtime property `bordertech.config.environment` is set, it is used as the suffix for each property lookup:
 
 ``` java properties
 ## MOCK Environment

--- a/README.md
+++ b/README.md
@@ -121,8 +121,21 @@ Sometimes you may need to include System Properties in the Configuration:
 |Property key|Description|Default value|
 |-------------|-----------|-------------|
 |bordertech.config.parameters.useSystemProperties|This flag allows system properties to be merged into the Configuration at the end of the loading process.|false|
-|bordertech.config.parameters.useSystemOverWriteOnly|This flag controls if a system property will only overwrite an existing property|true|
-|bordertech.config.parameters.useSystemPrefixes|Define a list of system attribute prefixes that are allowed to be merged. Default is allow all.|n/a|
+|bordertech.config.parameters.useSystemOverWriteOnly|This flag controls if a system property will only overwrite an existing property|false|
+|bordertech.config.parameters.useSystemPrefixes|Define a list of system property prefixes that are allowed to be merged. Default is allow all.|n/a|
+
+System properties will override properties in resource files.
+
+### Merge Environment Properties into Configuration
+
+Sometimes you may need to include Environment Properties in the Configuration:
+
+|Property key|Description|Default value|
+|-------------|-----------|-------------|
+|bordertech.config.parameters.useEnvProperties|This flag allows environment properties to be merged into the Configuration at the end of the loading process.|false|
+|bordertech.config.parameters.useEnvPrefixes|Define a list of environment property prefixes that are allowed to be merged. Default is allow all.|n/a|
+
+Environemnt properties will override system properties and properties in resource files.
 
 ### Merge Configuration into System Properties
 
@@ -161,7 +174,7 @@ The following methods in the `Config` class are useful for unit testing:
 
 ## Configuration
 
-The initial configuration of `Config` can be overridden by setting properties in a file `bordertech-config.properties`.
+The initial configuration of `Config` can be overridden by setting properties in a file `bordertech-config.properties`. The file name can be overriden via a System or Environment property `BT_CONFIG_FILE`.
 
 The following options can be set:-
 
@@ -171,6 +184,7 @@ The following options can be set:-
 |bordertech.config.spi.enabled|The flag to enable SPI lookup|true|
 |bordertech.config.spi.append.default|The flag to append the default configuration|true|
 |bordertech.config.resource.order|The list of property resources to load into the configuration. Priority of properties is in reverse order of the list.|bordertech-defaults.properties, bordertech-app.properties, bordertech-local.properties|
+|bordertech.config.resource.append|An optional list of extra property resources to append to the resources. Useful to add extra resources to the default resources.|n/a|
 
 ### Default Implementation
 
@@ -185,7 +199,7 @@ bordertech.config.default.impl=my.example.SpecialConfiguration
 Example of loading the default resources and a project specific resource:
 
 ``` java properties
-bordertech.config.resource.order+=my-project.properties
+bordertech.config.resource.append=my-project.properties
 ```
 
 ### SPI

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.github.bordertech.common</groupId>
 		<artifactId>qa-parent</artifactId>
-		<version>1.0.15</version>
+		<version>1.0.16</version>
 	</parent>
 
 	<packaging>jar</packaging>

--- a/src/main/java/com/github/bordertech/config/DefaultConfiguration.java
+++ b/src/main/java/com/github/bordertech/config/DefaultConfiguration.java
@@ -734,9 +734,9 @@ public class DefaultConfiguration implements Configuration {
 	private void loadSystemProperties() {
 		boolean overWriteOnly = getBoolean(USE_SYSTEM_OVERWRITEONLY, false);
 		List<String> allowedPrefixes = getList(USE_SYSTEM_PREFIXES);
-		System.getProperties().entrySet().forEach((entry) -> {
-			mergeExternalProperty("System Properties", (String) entry.getKey(), (String) entry.getValue(), overWriteOnly, allowedPrefixes);
-		});
+		System.getProperties().entrySet().forEach(entry
+				-> mergeExternalProperty("System Properties", (String) entry.getKey(), (String) entry.getValue(), overWriteOnly, allowedPrefixes)
+		);
 	}
 
 	/**
@@ -744,9 +744,9 @@ public class DefaultConfiguration implements Configuration {
 	 */
 	private void loadEnvironmentProperties() {
 		List<String> allowedPrefixes = getList(USE_OSENV_PREFIXES);
-		System.getenv().entrySet().forEach((entry) -> {
-			mergeExternalProperty("Environment Properties", entry.getKey(), entry.getValue(), false, allowedPrefixes);
-		});
+		System.getenv().entrySet().forEach(entry
+				-> mergeExternalProperty("Environment Properties", entry.getKey(), entry.getValue(), false, allowedPrefixes)
+		);
 	}
 
 	/**

--- a/src/main/java/com/github/bordertech/config/DefaultConfiguration.java
+++ b/src/main/java/com/github/bordertech/config/DefaultConfiguration.java
@@ -78,8 +78,11 @@ public class DefaultConfiguration implements Configuration {
 
 	/**
 	 * If merging System Properties this parameter controls if a system property will only overwrite an existing
-	 * property. The default is true.
+	 * property. The default is false.
+	 *
+	 * @deprecated Use {@link #USE_SYSTEM_PREFIXES} to control which properties can be merged
 	 */
+	@Deprecated
 	public static final String USE_SYSTEM_OVERWRITEONLY = "bordertech.config.parameters.useSystemOverWriteOnly";
 
 	/**
@@ -87,6 +90,18 @@ public class DefaultConfiguration implements Configuration {
 	 * to be merged. The default is allow all System Properties to be merged.
 	 */
 	public static final String USE_SYSTEM_PREFIXES = "bordertech.config.parameters.useSystemPrefixes";
+
+	/**
+	 * If this parameter is defined and resolves to true as a boolean, then the OS Environment properties will be merged
+	 * at the end of the loading process.
+	 */
+	public static final String USE_OSENV_PROPERTIES = "bordertech.config.parameters.useEnvProperties";
+
+	/**
+	 * If merging OS Environment Properties, this parameter can be used to define a list of attribute prefixes that are
+	 * allowed to be merged. The default is allow all Environment Properties to be merged.
+	 */
+	public static final String USE_OSENV_PREFIXES = "bordertech.config.parameters.useEnvPrefixes";
 
 	/**
 	 * If this parameter is set to true, then after loading the parameters, they will be dumped to the console.
@@ -295,6 +310,11 @@ public class DefaultConfiguration implements Configuration {
 			loadSystemProperties();
 		}
 
+		if (isUseOsEnvProperties()) {
+			recordMessage("Loading from environment properties");
+			loadEnvironmentProperties();
+		}
+
 		// Now perform variable substitution.
 		do {
 			// Do nothing while loop
@@ -326,6 +346,13 @@ public class DefaultConfiguration implements Configuration {
 	 */
 	private boolean isUseSystemProperties() {
 		return getBoolean(USE_SYSTEM_PROPERTIES) || getBoolean(LEGACY_USE_SYSTEM_PROPERTIES);
+	}
+
+	/**
+	 * @return true if load OS Environment properties into config
+	 */
+	private boolean isUseOsEnvProperties() {
+		return getBoolean(USE_OSENV_PROPERTIES);
 	}
 
 	/**
@@ -705,33 +732,51 @@ public class DefaultConfiguration implements Configuration {
 	 * Load the System Properties into Config.
 	 */
 	private void loadSystemProperties() {
-
-		boolean overWriteOnly = getBoolean(USE_SYSTEM_OVERWRITEONLY, true);
+		boolean overWriteOnly = getBoolean(USE_SYSTEM_OVERWRITEONLY, false);
 		List<String> allowedPrefixes = getList(USE_SYSTEM_PREFIXES);
+		System.getProperties().entrySet().forEach((entry) -> {
+			mergeExternalProperty("System Properties", (String) entry.getKey(), (String) entry.getValue(), overWriteOnly, allowedPrefixes);
+		});
+	}
 
-		for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
+	/**
+	 * Load the OS Environment Properties into Config.
+	 */
+	private void loadEnvironmentProperties() {
+		List<String> allowedPrefixes = getList(USE_OSENV_PREFIXES);
+		System.getenv().entrySet().forEach((entry) -> {
+			mergeExternalProperty("Environment Properties", entry.getKey(), entry.getValue(), false, allowedPrefixes);
+		});
+	}
 
-			String key = (String) entry.getKey();
-			String value = (String) entry.getValue();
+	/**
+	 * Merge the external property.
+	 *
+	 * @param location the location of the properties
+	 * @param key the property key
+	 * @param value the property value
+	 * @param overWriteOnly true if only overwrite existing properties
+	 * @param allowedPrefixes the list of allowed property prefixes
+	 */
+	private void mergeExternalProperty(final String location, final String key, final String value, final boolean overWriteOnly, final List<String> allowedPrefixes) {
 
-			// Check for "include" keys (should not come from System Properties)
-			if (INCLUDE.equals(key) || INCLUDE_AFTER.equals(key)) {
-				continue;
-			}
-
-			// Check allowed prefixes
-			if (!isAllowedKeyPrefix(allowedPrefixes, key)) {
-				continue;
-			}
-
-			// Check overwrite only
-			if (overWriteOnly && get(key) == null) {
-				continue;
-			}
-
-			// Load property
-			load(key, value, "System Properties");
+		// Check for "include" keys (should not come from System or Environment Properties)
+		if (INCLUDE.equals(key) || INCLUDE_AFTER.equals(key)) {
+			return;
 		}
+
+		// Check allowed prefixes
+		if (!isAllowedKeyPrefix(allowedPrefixes, key)) {
+			return;
+		}
+
+		// Check overwrite only
+		if (overWriteOnly && get(key) == null) {
+			return;
+		}
+
+		// Load property
+		load(key, value, location);
 	}
 
 	/**

--- a/src/main/java/com/github/bordertech/config/InitHelper.java
+++ b/src/main/java/com/github/bordertech/config/InitHelper.java
@@ -1,6 +1,8 @@
 package com.github.bordertech.config;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
@@ -23,6 +25,8 @@ import org.apache.commons.lang3.StringUtils;
  * <li>bordertech.config.spi.enabled - enable SPI lookup (default: true)</li>
  * <li>bordertech.config.spi.append.default - append the default configuration (default: true)</li>
  * <li>bordertech.config.resource.order - order of resources to load into the configuration</li>
+ * <li>bordertech.config.resource.append - append additional resources. This is helpful when adding extra resources to
+ * the default resources</li>
  * </ul>
  * <p>
  * The default resources Config looks for are:-
@@ -33,6 +37,10 @@ import org.apache.commons.lang3.StringUtils;
  * <li><code>bordertech-local.properties</code> - local developer properties</li>
  * </ul>
  *
+ * <p>
+ * Resources are ordered lowest to highest priority in determining which property value is used if property keys are
+ * duplicated.
+ * </p>
  *
  * @author Jonathan Austin
  * @since 1.0.0
@@ -47,6 +55,7 @@ public final class InitHelper {
 	private static final String PARAM_KEY_SPI_ENABLED = "bordertech.config.spi.enabled";
 	private static final String PARAM_KEY_SPI_APPEND_DEFAULT = "bordertech.config.spi.append.default";
 	private static final String PARAM_KEY_RESOURCE_ORDER = "bordertech.config.resource.order";
+	private static final String PARAM_KEY_RESOURCE_APPEND = "bordertech.config.resource.append";
 	private static final List<String> DEFAULT_BORDERTECH_LOAD_ORDER = Arrays.asList(
 			// The name of the first resource we look for is for internal default properties
 			"bordertech-defaults.properties",
@@ -73,15 +82,13 @@ public final class InitHelper {
 		// Load the config defaults (if exists)
 		String configFile = getDefaultConfigFileName();
 		Configuration configDefaults = loadPropertyFile(configFile);
+		// Default config impl
 		DEFAULT_CONFIG_IMPL = configDefaults.getString(PARAM_KEY_DEFAULT_CONFIG_IMPL, DefaultConfiguration.class.getName());
+		// Check if SPI enabled
 		SPI_APPEND_DEFAULT_CONFIG = configDefaults.getBoolean(PARAM_KEY_SPI_APPEND_DEFAULT, true);
 		SPI_ENABLED = configDefaults.getBoolean(PARAM_KEY_SPI_ENABLED, true);
-		String[] override = configDefaults.getStringArray(PARAM_KEY_RESOURCE_ORDER);
-		if (override == null || override.length == 0) {
-			DEFAULT_RESOURCE_LOAD_ORDER = DEFAULT_BORDERTECH_LOAD_ORDER;
-		} else {
-			DEFAULT_RESOURCE_LOAD_ORDER = Arrays.asList(override);
-		}
+		// Load resource order
+		DEFAULT_RESOURCE_LOAD_ORDER = getResourceOrder(configDefaults);
 	}
 
 	/**
@@ -141,6 +148,29 @@ public final class InitHelper {
 		name = System.getProperty(DEFAULTS_FILE_PARAM_KEY);
 		// If no system property, return the default file name
 		return StringUtils.isBlank(name) ? DEFAULTS_FILE_NAME : name;
+	}
+
+	/**
+	 * Retrieve the resource order.
+	 *
+	 * @param configDefaults the config defaults
+	 * @return the list of resources in load order
+	 */
+	private static List<String> getResourceOrder(final Configuration configDefaults) {
+		List<String> resources = new ArrayList<>();
+		// Check for default resource overrides
+		String[] override = configDefaults.getStringArray(PARAM_KEY_RESOURCE_ORDER);
+		if (override == null || override.length == 0) {
+			resources.addAll(DEFAULT_BORDERTECH_LOAD_ORDER);
+		} else {
+			resources.addAll(Arrays.asList(override));
+		}
+		// Check for append resources
+		String[] append = configDefaults.getStringArray(PARAM_KEY_RESOURCE_APPEND);
+		if (append != null && append.length > 0) {
+			resources.addAll(Arrays.asList(append));
+		}
+		return Collections.unmodifiableList(resources);
 	}
 
 }

--- a/src/main/java/com/github/bordertech/config/InitHelper.java
+++ b/src/main/java/com/github/bordertech/config/InitHelper.java
@@ -6,9 +6,16 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.ConfigurationUtils;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Helper class for {@link Config} initialisation.
+ * <p>
+ * The helper checks for configuration overrides by searching for a property file named
+ * <code>bordertech-config.properties</code> in the user home directory, the current classpath and the system classpath.
+ * The file name can be overridden by setting an environment or system property with the key
+ * <code>bordertech.config.file</code>.
+ * </p>
  * <p>
  * The following properties can be set:-
  * <ul>
@@ -34,6 +41,7 @@ import org.apache.commons.configuration.PropertiesConfiguration;
  */
 public final class InitHelper {
 
+	private static final String DEFAULTS_FILE_PARAM_KEY = "bordertech.config.file";
 	private static final String DEFAULTS_FILE_NAME = "bordertech-config.properties";
 	private static final String PARAM_KEY_DEFAULT_CONFIG_IMPL = "bordertech.config.default.impl";
 	private static final String PARAM_KEY_SPI_ENABLED = "bordertech.config.spi.enabled";
@@ -63,7 +71,8 @@ public final class InitHelper {
 
 	static {
 		// Load the config defaults (if exists)
-		Configuration configDefaults = loadPropertyFile(DEFAULTS_FILE_NAME);
+		String configFile = getDefaultConfigFileName();
+		Configuration configDefaults = loadPropertyFile(configFile);
 		DEFAULT_CONFIG_IMPL = configDefaults.getString(PARAM_KEY_DEFAULT_CONFIG_IMPL, DefaultConfiguration.class.getName());
 		SPI_APPEND_DEFAULT_CONFIG = configDefaults.getBoolean(PARAM_KEY_SPI_APPEND_DEFAULT, true);
 		SPI_ENABLED = configDefaults.getBoolean(PARAM_KEY_SPI_ENABLED, true);
@@ -115,6 +124,23 @@ public final class InitHelper {
 			configDefaults = new PropertiesConfiguration();
 		}
 		return configDefaults;
+	}
+
+	/**
+	 * Check if the default config file name has been overridden via environment or system properties.
+	 *
+	 * @return the default config file name
+	 */
+	private static String getDefaultConfigFileName() {
+		// Check environment variable
+		String name = System.getenv(DEFAULTS_FILE_PARAM_KEY);
+		if (!StringUtils.isBlank(name)) {
+			return name;
+		}
+		// Check system property
+		name = System.getProperty(DEFAULTS_FILE_PARAM_KEY);
+		// If no system property, return the default file name
+		return StringUtils.isBlank(name) ? DEFAULTS_FILE_NAME : name;
 	}
 
 }

--- a/src/main/java/com/github/bordertech/config/InitHelper.java
+++ b/src/main/java/com/github/bordertech/config/InitHelper.java
@@ -13,10 +13,9 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * Helper class for {@link Config} initialisation.
  * <p>
- * The helper checks for configuration overrides by searching for a property file named
- * <code>bordertech-config.properties</code> in the user home directory, the current classpath and the system classpath.
- * The file name can be overridden by setting an environment or system property with the key
- * <code>bordertech.config.file</code>.
+ * The helper checks for configuration overrides by searching for a property file named <code>BT_CONFIG_FILE</code> in
+ * the user home directory, the current classpath and the system classpath. The file name can be overridden by setting
+ * an environment or system property with the key <code>bordertech.config.file</code>.
  * </p>
  * <p>
  * The following properties can be set:-

--- a/src/main/java/com/github/bordertech/config/InitHelper.java
+++ b/src/main/java/com/github/bordertech/config/InitHelper.java
@@ -49,7 +49,7 @@ import org.apache.commons.lang3.StringUtils;
  */
 public final class InitHelper {
 
-	private static final String DEFAULTS_FILE_PARAM_KEY = "bordertech.config.file";
+	private static final String DEFAULTS_FILE_PARAM_KEY = "BT_CONFIG_FILE";
 	private static final String DEFAULTS_FILE_NAME = "bordertech-config.properties";
 	private static final String PARAM_KEY_DEFAULT_CONFIG_IMPL = "bordertech.config.default.impl";
 	private static final String PARAM_KEY_SPI_ENABLED = "bordertech.config.spi.enabled";

--- a/src/test/java/com/github/bordertech/config/ConfigTest.java
+++ b/src/test/java/com/github/bordertech/config/ConfigTest.java
@@ -33,4 +33,25 @@ public class ConfigTest {
 		String actual = config.getString("kung.fu");
 		Assert.assertEquals("Copy should maintain properties", expected, actual);
 	}
+
+	@Test
+	public void testResourceOrder() {
+		Configuration config = Config.getInstance();
+		Assert.assertEquals("Correct property value in defaults", "IN-DEFAULTS", config.getString("test.in.defaults"));
+		Assert.assertEquals("Correct property value in app", "IN-APP", config.getString("test.in.app"));
+		Assert.assertEquals("Correct property value in local", "IN-LOCAL", config.getString("test.in.local"));
+		Assert.assertEquals("Correct property value in extra first", "IN-EXTRA-FIRST", config.getString("test.in.extra.first"));
+		Assert.assertEquals("Correct property value in extra second", "IN-EXTRA-SECOND", config.getString("test.in.extra.second"));
+	}
+
+	@Test
+	public void testResourceOrderOverrides() {
+		Configuration config = Config.getInstance();
+		Assert.assertEquals("Correct property override value in defaults", "DEFAULTS-def", config.getString("test.override.defaults"));
+		Assert.assertEquals("Correct property override value in app", "APP-app", config.getString("test.override.app"));
+		Assert.assertEquals("Correct property override value in local", "LOCAL-local", config.getString("test.override.local"));
+		Assert.assertEquals("Correct property override value in extra first", "EXTRA-FIRST-extra-1", config.getString("test.override.extra.first"));
+		Assert.assertEquals("Correct property override value in extra second", "EXTRA-SECOND-extra-2", config.getString("test.override.extra.second"));
+	}
+
 }

--- a/src/test/java/com/github/bordertech/config/DefaultConfigurationEnvironmentTest.java
+++ b/src/test/java/com/github/bordertech/config/DefaultConfigurationEnvironmentTest.java
@@ -1,0 +1,39 @@
+package com.github.bordertech.config;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit test {@link DefaultConfiguration} for environment variables.
+ */
+public class DefaultConfigurationEnvironmentTest {
+
+	@Test
+	public void testEnvironmentVariablesDefault() {
+		DefaultConfiguration config = new DefaultConfiguration(
+				"com/github/bordertech/config/DefaultConfigurationTestLoadEnvDefault.properties");
+		// Check disabled
+		Assert.assertFalse("Use environment variables should defualt to false", config.getBoolean(DefaultConfiguration.USE_OSENV_PROPERTIES));
+		// If no environment variables cant do anything
+		if (!System.getenv().keySet().isEmpty()) {
+			// Get a environment variable
+			String key = System.getenv().keySet().iterator().next();
+			Assert.assertFalse("Environment variables should not be in config", config.containsKey(key));
+		}
+	}
+
+	@Test
+	public void testEnvironmentVariablesEnabled() {
+		DefaultConfiguration config = new DefaultConfiguration(
+				"com/github/bordertech/config/DefaultConfigurationTestLoadEnvEnabled.properties");
+		// Check enabled
+		Assert.assertTrue("Use environment variables should be enabled", config.getBoolean(DefaultConfiguration.USE_OSENV_PROPERTIES));
+		// If no environment variables cant do anything
+		if (!System.getenv().keySet().isEmpty()) {
+			// Get a environment variable
+			String key = System.getenv().keySet().iterator().next();
+			Assert.assertTrue("Environment variables should be in config", config.containsKey(key));
+		}
+	}
+
+}

--- a/src/test/java/com/github/bordertech/config/DefaultConfigurationSystemTest.java
+++ b/src/test/java/com/github/bordertech/config/DefaultConfigurationSystemTest.java
@@ -45,11 +45,11 @@ public class DefaultConfigurationSystemTest {
 	@Test
 	public void loadSystemOverWriteOnly() {
 		DefaultConfiguration config = new DefaultConfiguration(
-				"com/github/bordertech/config/DefaultConfigurationTestLoadSystem.properties");
+				"com/github/bordertech/config/DefaultConfigurationTestLoadSystemOverWriteOnly.properties");
 		// Check system settings in the test properties files
 		Assert.assertTrue(config.getBoolean(DefaultConfiguration.USE_SYSTEM_PROPERTIES));
 		// OverWriteOnly Enabled - ie using the default so no property set
-		Assert.assertFalse(config.containsKey(DefaultConfiguration.USE_SYSTEM_OVERWRITEONLY));
+		Assert.assertTrue(config.containsKey(DefaultConfiguration.USE_SYSTEM_OVERWRITEONLY));
 		// No prefixes set
 		Assert.assertFalse(config.containsKey(DefaultConfiguration.USE_SYSTEM_PREFIXES));
 		// Check properties
@@ -58,12 +58,12 @@ public class DefaultConfigurationSystemTest {
 	}
 
 	@Test
-	public void loadSystemOverWriteOnlyDisabled() {
+	public void loadSystemProperties() {
 		DefaultConfiguration config = new DefaultConfiguration(
-				"com/github/bordertech/config/DefaultConfigurationTestLoadSystemOverWrite.properties");
+				"com/github/bordertech/config/DefaultConfigurationTestLoadSystem.properties");
 		// Check system settings in the test properties files
 		Assert.assertTrue(config.getBoolean(DefaultConfiguration.USE_SYSTEM_PROPERTIES));
-		// OverWriteOnly disabled
+		// OverWriteOnly disabled (default)
 		Assert.assertFalse(config.getBoolean(DefaultConfiguration.USE_SYSTEM_OVERWRITEONLY));
 		// No prefixes set
 		Assert.assertFalse(config.containsKey(DefaultConfiguration.USE_SYSTEM_PREFIXES));

--- a/src/test/java/com/github/bordertech/config/InitHelperTest.java
+++ b/src/test/java/com/github/bordertech/config/InitHelperTest.java
@@ -1,0 +1,56 @@
+package com.github.bordertech.config;
+
+import java.util.Arrays;
+import org.apache.commons.configuration.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link InitHelper}.
+ */
+public class InitHelperTest {
+
+	private final String[] expectedResources = new String[]{
+		"bordertech-defaults.properties",
+		"bordertech-app.properties",
+		"bordertech-local.properties",
+		"bordertech-extra-first.properties",
+		"bordertech-extra-second.properties"};
+
+	private final String[] expectedBordertechResources = new String[]{
+		"bordertech-defaults.properties",
+		"bordertech-app.properties",
+		"bordertech-local.properties"};
+
+	@Test
+	public void testResourceLoadOrder() {
+		String[] resources = InitHelper.getDefaultResourceLoadOrder();
+		Assert.assertTrue("Incorrect resource load order", Arrays.deepEquals(expectedResources, resources));
+	}
+
+	@Test
+	public void testBordertechDefaultLoadOrder() {
+		String[] resources = InitHelper.getDefaultBordertechLoadOrder();
+		Assert.assertTrue("Incorrect bordertech resources", Arrays.deepEquals(expectedBordertechResources, resources));
+	}
+
+	@Test
+	public void loadPropertyFileExists() {
+		Configuration config = InitHelper.loadPropertyFile("bordertech-app.properties");
+		Assert.assertNotNull("Config for file should not be null", config);
+		Assert.assertEquals("Incorrect property value returned from config", "IN-APP", config.getString("test.in.app"));
+	}
+
+	@Test
+	public void loadPropertyFileNotExists() {
+		Configuration config = InitHelper.loadPropertyFile("NOT-EXIST.properties");
+		Assert.assertNotNull("Config for not existing file should not be null", config);
+		Assert.assertFalse("Config should be empty", config.getKeys().hasNext());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void loadPropertyFileInvalid() {
+		InitHelper.loadPropertyFile("InvalidPropertiesFile.properties");
+	}
+
+}

--- a/src/test/resources/InvalidPropertiesFile.properties
+++ b/src/test/resources/InvalidPropertiesFile.properties
@@ -1,0 +1,2 @@
+## This include will cause an error when testing InitHelper
+include=NotExists.properties

--- a/src/test/resources/bordertech-app.properties
+++ b/src/test/resources/bordertech-app.properties
@@ -1,0 +1,8 @@
+## Check properties are correctly overriden in resource order
+test.override.app=APP-app
+test.override.local=APP-local
+test.override.extra.first=APP-extra-1
+test.override.extra.second=APP-extra-2
+
+# Property only in app
+test.in.app=IN-APP

--- a/src/test/resources/bordertech-config.properties
+++ b/src/test/resources/bordertech-config.properties
@@ -1,0 +1,2 @@
+## Append the extra property to the default resources
+bordertech.config.resource.append=bordertech-extra-first.properties,bordertech-extra-second.properties

--- a/src/test/resources/bordertech-defaults.properties
+++ b/src/test/resources/bordertech-defaults.properties
@@ -1,0 +1,9 @@
+## Check properties are correctly overriden in resource order
+test.override.defaults=DEFAULTS-def
+test.override.app=DEFAULTS-app
+test.override.local=DEFAULTS-local
+test.override.extra.first=DEFAULTS-extra-1
+test.override.extra.second=DEFAULTS-extra-2
+
+# Property only in defaults
+test.in.defaults=IN-DEFAULTS

--- a/src/test/resources/bordertech-extra-first.properties
+++ b/src/test/resources/bordertech-extra-first.properties
@@ -1,0 +1,6 @@
+## Check properties are correctly overriden in resource order
+test.override.extra.first=EXTRA-FIRST-extra-1
+test.override.extra.second=EXTRA-FIRST-extra-2
+
+# Property only in extra
+test.in.extra.first=IN-EXTRA-FIRST

--- a/src/test/resources/bordertech-extra-second.properties
+++ b/src/test/resources/bordertech-extra-second.properties
@@ -1,0 +1,5 @@
+## Check properties are correctly overriden in resource order
+test.override.extra.second=EXTRA-SECOND-extra-2
+
+# Property only in extra second
+test.in.extra.second=IN-EXTRA-SECOND

--- a/src/test/resources/bordertech-local.properties
+++ b/src/test/resources/bordertech-local.properties
@@ -1,0 +1,7 @@
+## Check properties are correctly overriden in resource order
+test.override.local=LOCAL-local
+test.override.extra.first=LOCAL-extra-1
+test.override.extra.second=LOCAL-extra-2
+
+# Property only in local
+test.in.local=IN-LOCAL

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadEnvDefault.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadEnvDefault.properties
@@ -1,0 +1,12 @@
+############################################################################
+# This property file is for the DefaultConfiguration_Test jUnit test
+# It must not be included or be included by property file that is not
+# directly related to the test.
+############################################################################
+
+######
+###### Test load Environment Properties
+######
+
+## Load Environment Properties should default to false
+##bordertech.config.parameters.useEnvProperties=false

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadEnvEnabled.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadEnvEnabled.properties
@@ -1,0 +1,12 @@
+############################################################################
+# This property file is for the DefaultConfiguration_Test jUnit test
+# It must not be included or be included by property file that is not
+# directly related to the test.
+############################################################################
+
+######
+###### Test load Environment Properties
+######
+
+## Load Environment Properties Enabled
+bordertech.config.parameters.useEnvProperties=true

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadSystem.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadSystem.properties
@@ -14,5 +14,5 @@ bordertech.config.parameters.useSystemProperties=true
 ## Following Properties will be set in System.Properties and merged
 ## Should be overwritten as it exists
 simple.exists=value1
-## Should not be overwritten as not set
+## Should be merged even though not exist
 ##simple.notexists=

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadSystemOverWriteOnly.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadSystemOverWriteOnly.properties
@@ -8,8 +8,14 @@
 ###### Test Load System Properteis with OverWriteOnly Disabled
 ######
 
-## Test Properties
-include=com/github/bordertech/config/DefaultConfigurationTestLoadSystem.properties
+## Load System Properties
+bordertech.config.parameters.useSystemProperties=true
 
-## Disable Overwrite Only
-bordertech.config.parameters.useSystemOverWriteOnly=false
+## Following Properties will be set in System.Properties and merged
+## Should be overwritten as it exists
+simple.exists=value1
+## Should not be overwritten as not set
+##simple.notexists=
+
+## Enable Overwrite Only
+bordertech.config.parameters.useSystemOverWriteOnly=true


### PR DESCRIPTION
Similar to the functionality of loading System Properties, there is now an option to load Environment Variables. Closes #31
  - Enable Environment Variables via runtime property `bordertech.config.parameters.useEnvProperties=true`
  - Option to limit variables merged via property `bordertech.config.parameters.useEnvPrefixes`. Defaults to allow all.
- Ability to override the default config file name via a system or environment property `BT_CONFIG_FILE=my-config.properties`
- To be consistent with Environment and System property behaviour, the runtime property `bordertech.config.parameters.useSystemOverWriteOnly` now defaults to false which allows all system properties to be merged when system properties enabled. Use the optional runtime property `bordertech.config.parameters.useSystemPrefixes` to limit the properties merged.
- Option to append extra resources to the defined resources via config property `bordertech.config.resources.append`

Other changes:
- Latest qa-parent
- Fix travis sonar token
