### PR TITLE
Restore ability for profile suffix key to be substituted by another property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Release in-progress
 * Switch from travis-ci to GitHub Actions #46
 * Latest qa-parent and project dependencies
+* Restore ability for profile suffix key to refer to other property #49
 
 ## 1.0.7
 

--- a/src/main/java/com/github/bordertech/config/DefaultConfiguration.java
+++ b/src/main/java/com/github/bordertech/config/DefaultConfiguration.java
@@ -1,19 +1,5 @@
 package com.github.bordertech.config;
 
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConversionException;
-import org.apache.commons.configuration.MapConfiguration;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.SystemUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.impl.SimpleLog;
-import org.apache.commons.text.StringSubstitutor;
-
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -43,6 +29,19 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConversionException;
+import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.impl.SimpleLog;
+import org.apache.commons.text.StringSubstitutor;
 
 /**
  * <p>
@@ -103,6 +102,7 @@ public class DefaultConfiguration implements Configuration {
 	public static final String DUMP_FILE = "bordertech.config.parameters.dump.file";
 	/**
 	 * If this parameter is set, it will be used as the environment suffix for each property lookup.
+	 *
 	 * @deprecated Use {@link #PROFILE_PROPERTY} to define the profile property
 	 */
 	@Deprecated
@@ -215,8 +215,8 @@ public class DefaultConfiguration implements Configuration {
 	 */
 	public DefaultConfiguration(final String... resourceLoadOrder) {
 		if (resourceLoadOrder == null || resourceLoadOrder.length == 0 || Arrays
-			.stream(resourceLoadOrder)
-			.anyMatch(StringUtils::isBlank)) {
+				.stream(resourceLoadOrder)
+				.anyMatch(StringUtils::isBlank)) {
 			this.resourceLoadOrder = InitHelper.getDefaultResourceLoadOrder();
 		} else {
 			this.resourceLoadOrder = resourceLoadOrder;
@@ -228,7 +228,7 @@ public class DefaultConfiguration implements Configuration {
 	/**
 	 * Copies information from the input stream to the output stream using a specified buffer size.
 	 *
-	 * @param in  the source stream.
+	 * @param in the source stream.
 	 * @param out the destination stream.
 	 * @throws IOException if there is an error reading or writing to the streams.
 	 */
@@ -244,7 +244,6 @@ public class DefaultConfiguration implements Configuration {
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------
-
 	/**
 	 * Splits the given comma-delimited string into an an array. Leading/trailing spaces in list items will be trimmed.
 	 *
@@ -303,12 +302,9 @@ public class DefaultConfiguration implements Configuration {
 			loadEnvironmentProperties();
 		}
 
-		checkProfileProperty();
+		handlePropertySubstitution();
 
-		// Now perform variable substitution.
-		for (String key : backing.keySet()) {
-			substitute(key);
-		}
+		checkProfileProperty();
 
 		// Dump Header Info
 		LOG.info(getDumpHeader());
@@ -715,8 +711,8 @@ public class DefaultConfiguration implements Configuration {
 		boolean overWriteOnly = getBoolean(USE_SYSTEM_OVERWRITEONLY, false);
 		List<String> allowedPrefixes = Arrays.asList(getStringArray(USE_SYSTEM_PREFIXES));
 		System
-			.getProperties()
-			.forEach((key, value) -> mergeExternalProperty("System Properties",
+				.getProperties()
+				.forEach((key, value) -> mergeExternalProperty("System Properties",
 				(String) key,
 				(String) value,
 				overWriteOnly,
@@ -729,25 +725,25 @@ public class DefaultConfiguration implements Configuration {
 	private void loadEnvironmentProperties() {
 		List<String> allowedPrefixes = Arrays.asList(getStringArray(USE_OSENV_PREFIXES));
 		System
-			.getenv()
-			.forEach((key, value) -> mergeExternalProperty("Environment Properties", key, value, false, allowedPrefixes));
+				.getenv()
+				.forEach((key, value) -> mergeExternalProperty("Environment Properties", key, value, false, allowedPrefixes));
 	}
 
 	/**
 	 * Merge the external property.
 	 *
-	 * @param location        the location of the properties
-	 * @param key             the property key
-	 * @param value           the property value
-	 * @param overWriteOnly   true if only overwrite existing properties
+	 * @param location the location of the properties
+	 * @param key the property key
+	 * @param value the property value
+	 * @param overWriteOnly true if only overwrite existing properties
 	 * @param allowedPrefixes the list of allowed property prefixes
 	 */
 	private void mergeExternalProperty(
-		final String location,
-		final String key,
-		final String value,
-		final boolean overWriteOnly,
-		final List<String> allowedPrefixes) {
+			final String location,
+			final String key,
+			final String value,
+			final boolean overWriteOnly,
+			final List<String> allowedPrefixes) {
 
 		// Check for "include" keys (should not come from System or Environment Properties)
 		if (INCLUDE.equals(key) || INCLUDE_AFTER.equals(key)) {
@@ -772,7 +768,7 @@ public class DefaultConfiguration implements Configuration {
 	 * Check allowed prefixes.
 	 *
 	 * @param allowedPrefixes the list of allowed prefixes
-	 * @param key             the key to check
+	 * @param key the key to check
 	 * @return true if the key is an allowed prefix
 	 */
 	private boolean isAllowedKeyPrefix(final List<String> allowedPrefixes, final String key) {
@@ -1270,7 +1266,7 @@ public class DefaultConfiguration implements Configuration {
 	/**
 	 * Returns a sub-set of the parameters contained in this configuration.
 	 *
-	 * @param prefix   the prefix of the parameter keys which should be included.
+	 * @param prefix the prefix of the parameter keys which should be included.
 	 * @param truncate if true, the prefix is truncated in the returned properties.
 	 * @return the properties sub-set, may be empty.
 	 */
@@ -1309,7 +1305,7 @@ public class DefaultConfiguration implements Configuration {
 	}
 
 	/**
-	 * @param key    the property key
+	 * @param key the property key
 	 * @param defolt the default value if key not available
 	 * @return the property value or null
 	 */
@@ -1341,7 +1337,7 @@ public class DefaultConfiguration implements Configuration {
 	/**
 	 * Add or Modify a property at runtime.
 	 *
-	 * @param name  the property name
+	 * @param name the property name
 	 * @param value the property value
 	 */
 	protected void addOrModifyProperty(final String name, final String value) {
@@ -1368,6 +1364,16 @@ public class DefaultConfiguration implements Configuration {
 	}
 
 	/**
+	 * Handle the substitution of property values.
+	 */
+	protected void handlePropertySubstitution() {
+		// Now perform variable substitution.
+		for (String key : backing.keySet()) {
+			substitute(key);
+		}
+	}
+
+	/**
 	 * Handle a property change.
 	 */
 	protected void handlePropertiesChanged() {
@@ -1378,8 +1384,8 @@ public class DefaultConfiguration implements Configuration {
 	}
 
 	/**
-	 * Set the current Profile if it has been set as property. An application defined property overrides,
-	 * a JVM System property which overrides a OS environment variable
+	 * Set the current Profile if it has been set as property. An application defined property overrides, a JVM System
+	 * property which overrides a OS environment variable
 	 */
 	protected void checkProfileProperty() {
 
@@ -1452,8 +1458,9 @@ public class DefaultConfiguration implements Configuration {
 	/**
 	 * A helper class for properties which are being loaded into the {@link DefaultConfiguration}.
 	 *
-	 * <p>This is used to ensure on the call of put(key, value) is immediately loaded into the
-	 * {@link DefaultConfiguration} to respect the order hierarchy for the configuration.</p>
+	 * <p>
+	 * This is used to ensure on the call of put(key, value) is immediately loaded into the {@link DefaultConfiguration}
+	 * to respect the order hierarchy for the configuration.</p>
 	 */
 	private class IncludeProperties extends Properties {
 
@@ -1475,7 +1482,7 @@ public class DefaultConfiguration implements Configuration {
 		 * Adds a value to the properties set. This has been overridden to support the Configuration extensions (e.g.
 		 * the "include" directive).
 		 *
-		 * @param aKey   the key to add
+		 * @param aKey the key to add
 		 * @param aValue the value to add
 		 * @return the old value for the key, or null if there was no previously associated value.
 		 */

--- a/src/test/java/com/github/bordertech/config/DefaultConfigurationEnvProfileSuffixTest.java
+++ b/src/test/java/com/github/bordertech/config/DefaultConfigurationEnvProfileSuffixTest.java
@@ -9,7 +9,7 @@ import static com.github.bordertech.config.DefaultConfiguration.PROFILE_PROPERTY
 /**
  * DefaultConfiguration_EnvironmentSuffix_Test - JUnit tests for {@link DefaultConfiguration}.
  */
-public class DefaultConfigurationEnvSuffixTest {
+public class DefaultConfigurationEnvProfileSuffixTest {
 
 	private static final String TEST_PROPERTY_KEY = "default.propertyKey";
 	private static final String DEFAULT_PROPERTY_VALUE = "defaultValue";

--- a/src/test/java/com/github/bordertech/config/DefaultConfigurationSubstitutionBasicTest.java
+++ b/src/test/java/com/github/bordertech/config/DefaultConfigurationSubstitutionBasicTest.java
@@ -1,0 +1,44 @@
+package com.github.bordertech.config;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests to check substitution of values for {@link DefaultConfiguration}.
+ */
+public class DefaultConfigurationSubstitutionBasicTest {
+
+	private static final String EXPECTED_VALUEZ = "valueZ";
+	private static final String EXPECTED_VALUEZ2 = "valueZ2";
+
+	@Test
+	public void testSubstitutePropertyValuesBeforeDefined() {
+		DefaultConfiguration config = new DefaultConfiguration("com/github/bordertech/config/DefaultConfigurationTestSubstitution.properties");
+		Assert.assertEquals("Value for X should match Z value", EXPECTED_VALUEZ, config.get("substitute.test.X"));
+		Assert.assertEquals("Value for Y should match Z value", EXPECTED_VALUEZ, config.get("substitute.test.Y"));
+		Assert.assertEquals("Value for Z should be valueZ", EXPECTED_VALUEZ, config.get("substitute.test.Z"));
+	}
+
+	@Test
+	public void testSubstitutePropertyValuesReverseOrder() {
+		DefaultConfiguration config = new DefaultConfiguration("com/github/bordertech/config/DefaultConfigurationTestSubstitution.properties");
+		Assert.assertEquals("Value for X2 should match Z2 value", EXPECTED_VALUEZ2, config.get("substitute.test.X2"));
+		Assert.assertEquals("Value for Y2 should match Z2 value", EXPECTED_VALUEZ2, config.get("substitute.test.Y2"));
+		Assert.assertEquals("Value for Z2 should be valueZ2", EXPECTED_VALUEZ2, config.get("substitute.test.Z2"));
+	}
+
+	@Test
+	public void testSubstituteProfileSuffixKey() {
+		DefaultConfiguration config = new DefaultConfiguration("com/github/bordertech/config/DefaultConfigurationTestSubstitutionProfileSuffix.properties");
+		Assert.assertEquals("Profile value was not substituted", "TEST", config.get(DefaultConfiguration.PROFILE_PROPERTY));
+		Assert.assertEquals("Property value with profile suffix not correct", "PROFILE_TEST", config.get("substitute.test.profile"));
+	}
+
+	@Test
+	public void testSubstituteEnvSuffixKey() {
+		DefaultConfiguration config = new DefaultConfiguration("com/github/bordertech/config/DefaultConfigurationTestSubstitutionEnvSuffix.properties");
+		Assert.assertEquals("Environment value was not substituted", "TEST", config.get(DefaultConfiguration.ENVIRONMENT_PROPERTY));
+		Assert.assertEquals("Property value with environment suffix not correct", "ENV_TEST", config.get("substitute.test.env"));
+	}
+
+}

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationEnvSuffixTest.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationEnvSuffixTest.properties
@@ -4,6 +4,7 @@
 # directly related to the test.
 ############################################################################
 
+## Load the config environment property from the Systems Properties
 bordertech.config.parameters.useSystemProperties=true
 bordertech.config.parameters.useSystemPrefixes=bordertech.config.environment
 

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationEnvSuffixTest.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationEnvSuffixTest.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfigurationEnvSuffix_Test jUnit test
+# This property file is for the DefaultConfigurationEnvSuffixTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTest.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTest.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################
@@ -69,7 +69,7 @@ test.definedAfterInclude=mainValue
 includeAfter.test.path=com/github/bordertech/config
 
 # -------------------------------------------------------------------------------------------------
-# IncludeAfter tests 
+# IncludeAfter tests
 # -------------------------------------------------------------------------------------------------
 # This property is redefined in the includeAfter. The includeAfter definition should be effective.
 test.definedBeforeIncludeAfter=mainValue
@@ -83,7 +83,7 @@ test.plus.equals+=second
 
 includeAfter=${includeAfter.test.path}/DefaultConfigurationTest_includeAfterWithSubstitution.properties
 
-# Here for the test to prove that the immediately above includeAfter will override this 
+# Here for the test to prove that the immediately above includeAfter will override this
 test.includeAfter.secondaryString=anIncludeAfterWillOvverrideThis
 
 include=./path/to/a/non/existent/file.properties

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestDumpConsoleDisabled.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestDumpConsoleDisabled.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationDumpConsoleTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestDumpConsoleEnabled.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestDumpConsoleEnabled.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationDumpConsoleTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestDumpFileDisabled.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestDumpFileDisabled.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationDumpFileTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestDumpFileEnabled.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestDumpFileEnabled.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationDumpFileTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadEnvDefault.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadEnvDefault.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationEnvironmentTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadEnvEnabled.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadEnvEnabled.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationEnvironmentTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadSystem.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadSystem.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationSystemTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadSystemOverWriteOnly.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadSystemOverWriteOnly.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationSystemTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadSystemPrefixes.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestLoadSystemPrefixes.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationSystemTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestSubstitution.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestSubstitution.properties
@@ -1,0 +1,15 @@
+############################################################################
+# This property file is for the DefaultConfigurationSubstitutionBasicTest jUnit test
+# It must not be included or be included by property file that is not
+# directly related to the test.
+############################################################################
+
+## Test the substitution is handled when properties used before defined
+substitute.test.X=${substitute.test.Y}
+substitute.test.Y=${substitute.test.Z}
+substitute.test.Z=valueZ
+
+## Test the substitution in reverse order
+substitute.test.Z2=valueZ2
+substitute.test.Y2=${substitute.test.Z2}
+substitute.test.X2=${substitute.test.Y2}

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestSubstitutionEnvSuffix.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestSubstitutionEnvSuffix.properties
@@ -1,0 +1,12 @@
+############################################################################
+# This property file is for the DefaultConfigurationSubstitutionBasicTest jUnit test
+# It must not be included or be included by property file that is not
+# directly related to the test.
+############################################################################
+
+## Test deprecated Environment suffix with substitution
+substitute.test.myenv=TEST
+bordertech.config.environment=${substitute.test.myenv}
+## Property with a profile SUFFIX
+substitute.test.env=NO_ENV
+substitute.test.env.TEST=ENV_TEST

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestSubstitutionProfileSuffix.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTestSubstitutionProfileSuffix.properties
@@ -1,0 +1,13 @@
+############################################################################
+# This property file is for the DefaultConfigurationSubstitutionBasicTest jUnit test
+# It must not be included or be included by property file that is not
+# directly related to the test.
+############################################################################
+
+## Test profile suffix with substitution
+substitute.test.myprofile=TEST
+bordertech.config.profile=${substitute.test.myprofile}
+## Property with a profile SUFFIX
+substitute.test.profile=NO_PROFILE
+substitute.test.profile.TEST=PROFILE_TEST
+

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTest_include.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTest_include.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTest_includeAfter.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTest_includeAfter.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTest_includeAfterSecondary.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTest_includeAfterSecondary.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTest_includeAfterWithSubstitution.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTest_includeAfterWithSubstitution.properties
@@ -1,5 +1,5 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################
@@ -8,5 +8,5 @@ test.definedAfterIncludeAfterWithSubstitution=true
 
 includeAfter=${includeAfter.test.path}/DefaultConfigurationTest_includeAfterSecondary.properties
 
-# Here for the test to prove that the above includeAfter will override this 
+# Here for the test to prove that the above includeAfter will override this
 test.includeAfter.secondaryString=toBeOverridden

--- a/src/test/resources/com/github/bordertech/config/DefaultConfigurationTest_includeWithSubstitution.properties
+++ b/src/test/resources/com/github/bordertech/config/DefaultConfigurationTest_includeWithSubstitution.properties
@@ -1,8 +1,8 @@
 ############################################################################
-# This property file is for the DefaultConfiguration_Test jUnit test
+# This property file is for the DefaultConfigurationTest jUnit test
 # It must not be included or be included by property file that is not
 # directly related to the test.
 ############################################################################
-        
+
 test.property.included=true
 


### PR DESCRIPTION
Restore ability for profile suffix key to refer to and be substituted by another property. Closes #49
